### PR TITLE
Вывод непрочитанных сообщений при старте

### DIFF
--- a/libs/qmaxmessenger/api/chat.cpp
+++ b/libs/qmaxmessenger/api/chat.cpp
@@ -230,5 +230,5 @@ int Chat::participantsCount() const
 
 qint64 Chat::newMessagesCount() const
 {
-    return newMessagesCount;
+    return m_newMessagesCount;
 }

--- a/libs/qmaxmessenger/api/chat.h
+++ b/libs/qmaxmessenger/api/chat.h
@@ -37,7 +37,7 @@ class Chat : public QObject
     Q_PROPERTY(qint64 lastFireDelayedErrorTime READ lastFireDelayedErrorTime NOTIFY chatChanged FINAL)
     Q_PROPERTY(qint64 lastDelayedUpdateTime READ lastDelayedUpdateTime NOTIFY chatChanged FINAL)
     Q_PROPERTY(int prevMessageId READ prevMessageId NOTIFY chatChanged FINAL)
-    Q_PROPERTY(qint64 newMessagesCount READ newMessages NOTIFY chatChanged)
+    Q_PROPERTY(qint64 newMessagesCount READ newMessagesCount NOTIFY chatChanged)
     Q_PROPERTY(Access access READ access NOTIFY chatChanged FINAL)
 //TODO options
     Q_PROPERTY(QDateTime modified READ modified NOTIFY chatChanged FINAL)

--- a/libs/qmaxmessenger/models/chatslistmodel.cpp
+++ b/libs/qmaxmessenger/models/chatslistmodel.cpp
@@ -38,6 +38,7 @@ ChatsListModel::ChatsListModel(QObject *parent)
     m_hash.insert(Qt::UserRole + 4, QByteArray("chatIcon"));
     m_hash.insert(Qt::UserRole + 5, QByteArray("lastEventTime"));
     m_hash.insert(Qt::UserRole + 6, QByteArray("canSendMessage"));
+    m_hash.insert(Qt::UserRole + 7, QByteArray("unreadCount"));
 }
 
 int ChatsListModel::rowCount(const QModelIndex &parent) const
@@ -98,6 +99,8 @@ QVariant ChatsListModel::data(const QModelIndex &index, int role) const
         return item->lastEventTime();
     } else if (role == Qt::UserRole + 6) {
         return item->type() != Chat::CHANNEL;
+    } else if (role == Qt::UserRole + 7) {
+        return item->newMessagesCount();
     }
 
     return QVariant();


### PR DESCRIPTION
- Исправлены "осяпятки" при выводе метода newMessagesCount в Chat api
- 
- Сделан вывод newMessageCount при запуске приложения в ChatListModel